### PR TITLE
correct mistakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ clean:
 	rm -f sysmemsim
 	rm -f mymalloc
 	rm -f genrandms
-
+	rm -f mysmemsim


### PR DESCRIPTION
I appreciate your codes and lean a lot from your post.
When I copy codes from your post http://troydm.github.io/blog/2015/08/03/lifting-shadows-off-a-memory-allocation/, and compile by myself, I encounter several mistakes.
## The first one, pointer arithemetic. 
For example
```
int main() {
    uint32_t t = 33554432;
    cout << (void*)(0x555557559000 + -t) << endl;
    cout << (void*)(0x555557559000 -t) << endl;
}
output:
0x555655559000
0x555555559000
```
the above addition operations of pointer seemly do the same things, but for unsigned type appended minus in addition operation do not equal "substract". Given the macro you writed `#define shift_block_ptr(b,s) ((memory_block*)(shift_ptr(b,s)))` https://github.com/jiang1997/mymalloc/blob/f0def2575e41960d6a34e2b81aaa3c40800f9478/mymalloc.c#L104, I simply squeeze into explicitly type casting to "int". 

## The second one
The size field of memory_block should preserve the whole block size instead of the size that the applicant applies for.

## By the way
There is minor performance improvement after correction.
```
$ ./mymemsim -t 1 -r 500 test.ms
memory simulation took 1497ms
```

before
```
$ ./mymemsim -t 1 -r 500 test.ms
memory simulation took 1529ms
```
I heard some news about your country. Wish you all is well.